### PR TITLE
Submission of enmSdmX

### DIFF
--- a/inst/extdata/packages/enmSdmX.yaml
+++ b/inst/extdata/packages/enmSdmX.yaml
@@ -1,0 +1,32 @@
+name : "enmSdmX"
+title: "Species Distribution Modeling and Ecological Niche Modeling"
+version: "1.0.3"
+author: "Adam B. Smith"
+maintainer: "Adam B. Smith"
+cran: yes
+repository: "https://github.com/adamlilith/enmSdmX"
+description: "Implements species distribution modeling and ecological niche modeling, including: bias correction, spatial cross-validation, model evaluation, raster interpolation, biotic "velocity" (speed and direction of movement of a "mass" represented by a raster), interpolating across a time series of rasters, and use of spatially imprecise records. The heart of the package is a set of "training" functions which automatically optimize model complexity based number of available occurrences. These algorithms include MaxEnt, MaxNet, boosted regression trees/gradient boosting machines, generalized additive models, generalized linear models, natural splines, and random forests. To enhance interoperability with other modeling packages, no new classes are created. The package works with 'PROJ6' geodetic objects and coordinate reference systems."
+occ_acquisition: no
+occ_cleaning: no
+data_integration: no
+env_collinearity: no
+env_process: no
+bias: yes
+study_region: no
+backg_sample: no
+data_partitioning: yes
+mod_fit: yes
+mod_tuning: yes
+mod_ensemble: no
+mod_stack: no
+mod_evaluate: yes
+mod_multispecies: no
+mod_mechanistic: no
+pred_general: no
+pred_extrapolation: no
+pred_inspect: no
+post_processing: no
+gui: no
+metadata: no
+manuscript_citation: "Smith, A.B., Murphy, S.J., Henderson, D., and Erickson, K.D. 2023. Including imprecisely georeferenced specimens improves accuracy of species distribution models and estimates of niche breadth.  Global Ecology and Biogeography 32:342-255"
+manuscript_doi: "10.1111/geb.13628; 10.1101/2021.06.10.447988"

--- a/inst/extdata/packages/enmSdmX.yaml
+++ b/inst/extdata/packages/enmSdmX.yaml
@@ -1,4 +1,4 @@
-name : "enmSdmX"
+name: "enmSdmX"
 title: "Species Distribution Modeling and Ecological Niche Modeling"
 version: "1.0.3"
 author: "Adam B. Smith"

--- a/inst/extdata/packages/enmSdmX.yaml
+++ b/inst/extdata/packages/enmSdmX.yaml
@@ -2,10 +2,10 @@ name: "enmSdmX"
 title: "Species Distribution Modeling and Ecological Niche Modeling"
 version: "1.0.3"
 author: "Adam B. Smith"
-maintainer: "Adam B. Smith"
+maintainer: "Adam B. Smith <adam.smith@mobot.org>"
 cran: yes
 repository: "https://github.com/adamlilith/enmSdmX"
-description: "Implements species distribution modeling and ecological niche modeling, including: bias correction, spatial cross-validation, model evaluation, raster interpolation, biotic "velocity" (speed and direction of movement of a "mass" represented by a raster), interpolating across a time series of rasters, and use of spatially imprecise records. The heart of the package is a set of "training" functions which automatically optimize model complexity based number of available occurrences. These algorithms include MaxEnt, MaxNet, boosted regression trees/gradient boosting machines, generalized additive models, generalized linear models, natural splines, and random forests. To enhance interoperability with other modeling packages, no new classes are created. The package works with 'PROJ6' geodetic objects and coordinate reference systems."
+description: "Implements species distribution modeling and ecological niche modeling, including: bias correction, spatial cross-validation, model evaluation, raster interpolation, biotic \"velocity\" (speed and direction of movement of a \"mass\" represented by a raster), interpolating across a time series of rasters, and use of spatially imprecise records. The heart of the package is a set of \"training\" functions which automatically optimize model complexity based number of available occurrences. These algorithms include MaxEnt, MaxNet, boosted regression trees/gradient boosting machines, generalized additive models, generalized linear models, natural splines, and random forests. To enhance interoperability with other modeling packages, no new classes are created. The package works with 'PROJ6' geodetic objects and coordinate reference systems."
 occ_acquisition: no
 occ_cleaning: no
 data_integration: no


### PR DESCRIPTION
Added all required fields for enmSdmX. Functions for that pertain to fields for which I selected "yes":

bias:
* weightByDist: Calculates weights for points based on proximity to other points and the distance of spatial autocorrelation as per the "inverse-p" weighting method; Stolar & Nielsen 2015 Diversity and Distributions 21:595-608)
* geoThin: Thin geographic points deterministically or randomly

data_partitioning:
* geoFold: Create mutually-exclusive geographic partitions based on spatial clumps in presences

mod_fit:
* trainBRT, trainGAM, trainGLM, trainMaxEnt, trainMaxNet, trainNS, trainRF: Each functions conducts a grid search across a suite of tuning parameters.
* trainByCrossValid and summaryByCrossValid: Use one of the trainXYZ functions in a data-partitioned procedure to fit the respective model

mod_tuning: (As model_fit).

mod_evaluate:
* evalAUC, evalContBoyce, evalMultiAUC, evalThreshold, evalThresholdStats: Calculate AUC, CBI, etc. The primary difference between these functions and those in other packages is that these allow for site-level weights (e.g., to cancel bias).
