### PR TITLE
ShinyBIOMOD submission

### DIFF
--- a/inst/extdata/packages/ShinyBIOMOD.yaml
+++ b/inst/extdata/packages/ShinyBIOMOD.yaml
@@ -1,0 +1,38 @@
+name: ShinyBIOMOD
+title: A R application for Modelling Species Distributions
+version: 0.0.0.9000
+author: "Ian Ondo, Wilfried Thuiller, Maya Gueguen, Alexandre Antonelli, Samuel Pironon"
+maintainer: Ian Ondo <i.ondo@kew.org>
+cran: no
+repository: https://gitlab.com/IanOndo/shinybiomod
+description: "A R-based toolbox for building species distribution models. The package prodives a user-friendly interface
+to biomod, a widely used ensemble platform for species distribution modelling. In addition, it includes a wide variety of 
+tools to explore and address collinearity of environmental data, correct geographic sampling biases in occurrence data
+and delineate the training area. The Graphical User Interface (GUI) allows to explore, visualise, upload and download inputs/outputs.
+It is designed to smoothly handle the navigation along the workflow by timely displaying a range of signal features to help communicate
+various information. ShinyBIOMOD automatically creates a folder structure that saves outputs, thus ensures the trackability of inputs and
+the portability of the results."
+occ_acquisition: no
+occ_cleaning: no
+data_integration: no
+env_collinearity: yes
+env_process: no
+bias: yes
+study_region: yes
+backg_sample: yes
+data_partitioning: no
+mod_fit: yes
+mod_tuning: yes
+mod_ensemble: yes
+mod_stack: no
+mod_evaluate: yes
+mod_multispecies: no
+mod_mechanistic: no
+pred_general: yes
+pred_extrapolation: no
+pred_inspect: yes
+post_processing: no
+gui: yes
+metadata: no
+manuscript_citation:
+manuscript_doi:

--- a/inst/extdata/packages/ShinyBIOMOD.yaml
+++ b/inst/extdata/packages/ShinyBIOMOD.yaml
@@ -34,5 +34,5 @@ pred_inspect: yes
 post_processing: no
 gui: yes
 metadata: no
-manuscript_citation:
-manuscript_doi:
+manuscript_citation: ""
+manuscript_doi: ""


### PR DESCRIPTION
All yeses are similar to biomod2 submission exept the following:
env_collinearity: ShinyBIOMOD allows to perform a PCA, compute correlations and VIF values from a rasterstack of environmental variables.
study_region: ShinyBIOMOd allows to constrain the study area to a user-defined vector layer, a convex hull, a bounding box or circular buffers around points.